### PR TITLE
Clean up dependencies, update to embedded-hal digital v2 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ repository = "https://github.com/zklapow/keymatrix"
 license = "MIT"
 
 [dependencies]
-cortex-m = "~0.5"
-generic-array = "~0.11"
-embedded-hal = "~0.2"
+generic-array = "~0.13"
 
 [dev-dependencies]
 cortex-m = "~0.5"
@@ -23,7 +21,7 @@ samd21g18a = "~0.2"
 samd21_mini = "~0.1"
 panic-abort = "~0.2"
 
-[[print_matrix]]
+[[example]]
 name = "print_matrix"
 required-features = ["samd21"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ impl<CN, RN, C, R> KeyMatrix<CN, RN, C, R> where RN: Unsigned + ArrayLength<bool
                                                  C: KeyColumns<CN>,
                                                  R: KeyRows<RN>,
 {
+    /// Create a new key matrix with the given column and row structs.
+    ///
+    /// The debounce parameter specifies in how many subsequent calls of
+    /// `poll()` a key has to be registered as pressed, in order to be
+    /// considered pressed by `current_state()`.
     pub fn new(debounce_count: u8, cols: C, rows: R) -> Self {
         KeyMatrix {
             cols,
@@ -52,6 +57,11 @@ impl<CN, RN, C, R> KeyMatrix<CN, RN, C, R> where RN: Unsigned + ArrayLength<bool
         return GenericArray::generate(|_i| GenericArray::generate(|_j| 0u8));
     }
 
+    /// Scan the key matrix once.
+    ///
+    /// If the matrix was created with a `debounce_count > 0`, this must be
+    /// called at least that number of times + 1 to actually show a key as
+    /// pressed.
     pub fn poll(&mut self) -> Result<(), ()> {
         for i in 0..<CN as Unsigned>::to_usize() {
             self.cols.enable_column(i)?;
@@ -74,6 +84,7 @@ impl<CN, RN, C, R> KeyMatrix<CN, RN, C, R> where RN: Unsigned + ArrayLength<bool
         Ok(())
     }
 
+    /// Return a 2-dimensional array of the last polled state of the matrix.
     pub fn current_state(&self) -> GenericArray<GenericArray<bool, RN>, CN> {
         self.state.clone()
             .map(|col| {
@@ -83,10 +94,12 @@ impl<CN, RN, C, R> KeyMatrix<CN, RN, C, R> where RN: Unsigned + ArrayLength<bool
             })
     }
 
+    /// Return the number of rows that the matrix was created with.
     pub fn row_size(&self) -> usize {
         <RN as Unsigned>::to_usize()
     }
 
+    /// Return the number of columns that the matrix was created with.
     pub fn col_size(&self) -> usize {
         <CN as Unsigned>::to_usize()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate cortex_m;
-extern crate embedded_hal as hal;
 extern crate generic_array;
 
 use core::marker::PhantomData;
@@ -9,7 +7,6 @@ use generic_array::{ArrayLength, GenericArray};
 use generic_array::sequence::GenericSequence;
 use generic_array::functional::FunctionalSequence;
 use generic_array::typenum::Unsigned;
-use hal::timer::{CountDown, Periodic};
 
 pub trait KeyColumns<N: Unsigned> {
     fn size(&self) -> N;
@@ -40,22 +37,12 @@ impl<CN, RN, C, R> KeyMatrix<CN, RN, C, R> where RN: Unsigned + ArrayLength<bool
                                                  C: KeyColumns<CN>,
                                                  R: KeyRows<RN>,
 {
-    pub fn new<TU, CT, T>(counter: &mut CT,
-                          freq: T,
-                          debounce_count: u8,
-                          cols: C,
-                          rows: R) -> KeyMatrix<CN, RN, C, R>
-        where T: Into<TU>,
-              CT: CountDown<Time=TU> + Periodic,
-              C: KeyColumns<CN>,
-              R: KeyRows<RN>,
-    {
-        counter.start(freq.into());
+    pub fn new(debounce_count: u8, cols: C, rows: R) -> Self {
         KeyMatrix {
             cols,
             rows,
             debounce_count,
-            state: KeyMatrix::<CN, RN, C, R>::init_state(),
+            state: Self::init_state(),
             _cn: PhantomData,
             _cr: PhantomData,
         }


### PR DESCRIPTION
The first commit removes the need to pass a counter which is only used once, and some unused dependencies.

The second commit makes the keypad work with the embedded-hal digital::v2 API by allowing read and write to return errors.

If you find these changes to be useful, I have more ideas in mind, such as passing an optional Enum for keys names, and keeping track of press/release events.